### PR TITLE
Expose llama cpp configuration in Poyro

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @poyro/vitest
 
+## 0.5.0
+
+### Minor Changes
+
+- Improvements to default configuration and model to improve performance:
+
+  - Update model from llama-3 to phi-3.1, a model that is half the size, runs 3x faster, and has the same performance on eval dataset.
+  - Change default vitest configuration created by npx poyro init to do sequential execution, verbose reporting, and use forks (better for debugging).
+  - Create a way to interpret `poyro.config.js` files to configure library.
+  - Set default llama cpp parameters to more memory efficient configuration that better leverages GPU hardware.
+  - Change documentation to detail how to configure Poyro, specifically Llama cpp.
+
+  Inclusion of evaluation logic for future model changes and default poyro config from CLI to be done in a future release.
+
 ## 0.4.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poyro",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @poyro/docs
 
+## 0.4.0
+
+### Minor Changes
+
+- Improvements to default configuration and model to improve performance:
+
+  - Update model from llama-3 to phi-3.1, a model that is half the size, runs 3x faster, and has the same performance on eval dataset.
+  - Change default vitest configuration created by npx poyro init to do sequential execution, verbose reporting, and use forks (better for debugging).
+  - Create a way to interpret `poyro.config.js` files to configure library.
+  - Set default llama cpp parameters to more memory efficient configuration that better leverages GPU hardware.
+  - Change documentation to detail how to configure Poyro, specifically Llama cpp.
+
+  Inclusion of evaluation logic for future model changes and default poyro config from CLI to be done in a future release.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poyro/docs",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/docs/src/app/configuration/page.md
+++ b/packages/docs/src/app/configuration/page.md
@@ -1,0 +1,63 @@
+---
+title: Configuration
+nextjs:
+  metadata:
+    title: Configuration
+    description: Learn how to configure Poyro for your project.
+---
+
+Poyro uses sane defaults for its underlying libraries, but you can configure it to suit your needs. This page will walk you through the configuration options available in Poyro.
+
+## Configuration file
+
+Poyro uses a configuration file to manage its settings. Poyro looks for a file named `poyro.config.js` in the root of your project. A sample configuration file might look like this:
+
+```javascript
+import defineConfig from "@poyro/vitest/config";
+
+export default defineConfig({});
+```
+
+This configuration file is a JavaScript module that exports a configuration object. The example above changes no settings from the default configuration.
+
+To make changes, follow the instructions below.
+
+## Llama.cpp
+
+Poyro uses `node-llama-cpp` under the hood to run a local LLM. You can configure the settings for `node-llama-cpp` by passing an object to the `llamaCpp` key in the configuration object. There can be additional objects within the `llamaCpp` object to configure the LLM:
+
+- `frameworkOptions`: An object that contains options for the node-llama-cpp framework.
+- `modelOptions`: An object that contains options for the LLM model being used.
+- `contextOptions`: An object that contains options for the LLM context.
+
+The default config used by Poyro is the following:
+
+```javascript
+export const defaultConfig = {
+  llamaCpp: {
+    frameworkOptions: {
+      vramPadding: 0,
+      debug: false,
+    },
+    modelOptions: {
+      gpuLayers: 33,
+    },
+    contextOptions: {
+      contextSize: 512,
+      seed: 9,
+    },
+  },
+};
+```
+
+### Framework options
+
+See [here](https://github.com/withcatai/node-llama-cpp/blob/beta/src/bindings/getLlama.ts#L36-L132) for the full list of options available for the framework.
+
+### Model options
+
+See [here](https://github.com/withcatai/node-llama-cpp/blob/beta/src/evaluator/LlamaModel/LlamaModel.ts#L23-L148) for the full list of options available for the model.
+
+### Context options
+
+See [here](https://github.com/withcatai/node-llama-cpp/blob/beta/src/evaluator/LlamaContext/types.ts#L5-L91) for the full list of options available for the context.

--- a/packages/docs/src/lib/navigation.ts
+++ b/packages/docs/src/lib/navigation.ts
@@ -5,6 +5,7 @@ export const navigation = [
       { title: "Getting started", href: "/" },
       { title: "Manual installation", href: "/manual-installation" },
       { title: "How does it work?", href: "/how-does-it-work" },
+      { title: "Configuration", href: "/configuration" },
     ],
   },
   // {

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @poyro/vitest
 
-## 0.4.0
-
-### Minor Changes
-
-- 01f439c: Create a way to interpret `poyro.config.js` files to configure library.
-
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @poyro/vitest
 
+## 0.4.0
+
+### Minor Changes
+
+- 01f439c: Create a way to interpret `poyro.config.js` files to configure library.
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @poyro/vitest
 
+## 0.4.0
+
+### Minor Changes
+
+- Improvements to default configuration and model to improve performance:
+
+  - Update model from llama-3 to phi-3.1, a model that is half the size, runs 3x faster, and has the same performance on eval dataset.
+  - Change default vitest configuration created by npx poyro init to do sequential execution, verbose reporting, and use forks (better for debugging).
+  - Create a way to interpret `poyro.config.js` files to configure library.
+  - Set default llama cpp parameters to more memory efficient configuration that better leverages GPU hardware.
+  - Change documentation to detail how to configure Poyro, specifically Llama cpp.
+
+  Inclusion of evaluation logic for future model changes and default poyro config from CLI to be done in a future release.
+
 ## 0.3.4
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poyro/vitest",
-  "version": "0.4.0",
+  "version": "0.3.4",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poyro/vitest",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -10,6 +10,19 @@
     "dist/**",
     "constants.json"
   ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./*": "./*",
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "default": "./dist/config.js"
+    }
+  },
   "engines": {
     "node": ">=20.0.0"
   },
@@ -37,6 +50,8 @@
     "find-cache-dir": "^5.0.0",
     "handlebars": "^4.7.8",
     "node-fetch": "^3.3.2",
-    "node-llama-cpp": "3.0.0-beta.36"
+    "node-llama-cpp": "3.0.0-beta.36",
+    "radash": "^12.1.0",
+    "yup": "^1.4.0"
   }
 }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poyro/vitest",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -1,17 +1,41 @@
-import type { 
-  LlamaContextOptions, 
-  LlamaModelOptions, 
-  LlamaOptions
+import type {
+  LlamaContextOptions,
+  LlamaModelOptions,
+  LlamaOptions,
 } from "node-llama-cpp";
 
-interface llamaCppConfig {
-    frameworkOptions?: LlamaOptions,
-    modelOptions?: LlamaModelOptions,
-    contextOptions?: LlamaContextOptions,
+export interface LlamaCppConfig {
+  /** Options for the Node Llama.cpp framework */
+  frameworkOptions?: Partial<LlamaOptions>;
+  /** Options for the Llama model being used */
+  modelOptions?: Partial<LlamaModelOptions>;
+  /** Options for the Llama context being used */
+  contextOptions?: Partial<LlamaContextOptions>;
 }
 
-function defineConfig(config: llamaCppConfig): llamaCppConfig {
-    return config;
+export interface PoyroVitestConfig {
+  /** Configuration for Llama.cpp */
+  llamaCpp?: Partial<LlamaCppConfig>;
 }
+
+export const defaultConfig: PoyroVitestConfig = {
+  llamaCpp: {
+    frameworkOptions: {
+      vramPadding: 0,
+      debug: false,
+    },
+    modelOptions: {
+      gpuLayers: 33,
+    },
+    contextOptions: {
+      contextSize: 512,
+      seed: 9,
+    },
+  },
+};
+
+const defineConfig = (config: PoyroVitestConfig): PoyroVitestConfig => {
+  return config;
+};
 
 export default defineConfig;

--- a/packages/vitest/src/config.ts
+++ b/packages/vitest/src/config.ts
@@ -1,0 +1,17 @@
+import type { 
+  LlamaContextOptions, 
+  LlamaModelOptions, 
+  LlamaOptions
+} from "node-llama-cpp";
+
+interface llamaCppConfig {
+    frameworkOptions?: LlamaOptions,
+    modelOptions?: LlamaModelOptions,
+    contextOptions?: LlamaContextOptions,
+}
+
+function defineConfig(config: llamaCppConfig): llamaCppConfig {
+    return config;
+}
+
+export default defineConfig;

--- a/packages/vitest/src/makeModel.ts
+++ b/packages/vitest/src/makeModel.ts
@@ -14,6 +14,7 @@ import {
 } from "node-llama-cpp";
 
 import { getModelPath } from "./utils/getModelPath";
+import { getConfig } from "./utils/getConfig";
 
 export interface SessionOptions {
   /** The system prompt to use */
@@ -36,8 +37,11 @@ export class PoyroModelCore {
       return this.contextSequence;
     }
 
+    const { llamaCpp } = await getConfig();
+    const contextOptions = llamaCpp?.contextOptions || {};
+
     // Otherwise, create a new context
-    const context = await this.model.createContext();
+    const context = await this.model.createContext(contextOptions);
 
     // Then get the sequence
     this.contextSequence = context.getSequence();
@@ -86,9 +90,14 @@ export const makeModel = async (): Promise<PoyroModelCore> => {
   // Put together the file path
   const modelPath = path.join(dirPath, filename);
 
+  // Get config
+  const { llamaCpp } = await getConfig();
+  const llamaOptions = llamaCpp?.frameworkOptions || {};
+  const modelOptions = llamaCpp?.modelOptions || {};
+
   // Create a new llama model
-  const llama = await getLlama();
-  const model = await llama.loadModel({ modelPath });
+  const llama = await getLlama(llamaOptions);
+  const model = await llama.loadModel({ modelPath, ...modelOptions });
 
   return new PoyroModelCore(llama, model);
 };

--- a/packages/vitest/src/utils/getConfig.ts
+++ b/packages/vitest/src/utils/getConfig.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { assign } from "radash";
+
+import type { PoyroVitestConfig } from "../config";
+import { defaultConfig } from "../config";
+
+import { validateConfig } from "./validateConfig";
+
+export const getConfig = async (): Promise<PoyroVitestConfig> => {
+  // Get current working dir
+  const cwd = process.cwd();
+
+  // Get the config file path
+  const configPath = path.resolve(cwd, "poyro.config.js");
+
+  // If the file does not exist, return the default config
+  if (!fs.existsSync(configPath)) {
+    return validateConfig(defaultConfig);
+  }
+
+  // Otherwise, require the config file
+  const config = (await import(configPath).then(
+    (m) => m.default
+  )) as PoyroVitestConfig;
+
+  // If the config is not an object, throw an error
+  if (typeof config !== "object") {
+    throw new Error("The config must be an object.");
+  }
+
+  // If the config file is not valid, throw an error
+  if (!config) {
+    throw new Error("Something went wrong while loading the config file.");
+  }
+
+  // Return the merged config
+  return validateConfig(assign(defaultConfig, config));
+};

--- a/packages/vitest/src/utils/index.ts
+++ b/packages/vitest/src/utils/index.ts
@@ -1,2 +1,4 @@
+export * from "./getConfig";
 export * from "./log";
 export * from "./makeLogMessage";
+export * from "./validateConfig";

--- a/packages/vitest/src/utils/validateConfig.ts
+++ b/packages/vitest/src/utils/validateConfig.ts
@@ -1,0 +1,160 @@
+import { LlamaLogLevel } from "node-llama-cpp";
+import type { Schema } from "yup";
+import { array, boolean, lazy, mixed, number, object, string } from "yup";
+
+import type { PoyroVitestConfig } from "../config";
+
+type Shape<DType extends object, Strict = true> = {
+  [Key in keyof (Strict extends true
+    ? DType
+    : Partial<DType>)]: DType[Key] extends any[]
+    ? Schema<DType[Key]>
+    : DType[Key] extends object
+      ? Strict extends true
+        ? Schema<DType[Key]>
+        : Schema<Partial<DType[Key]>>
+      : Schema<DType[Key]>;
+};
+
+const _configSchema = object().shape<Shape<PoyroVitestConfig>>({
+  llamaCpp: object()
+    .shape({
+      frameworkOptions: object({
+        gpu: lazy((value) => {
+          return typeof value === "boolean"
+            ? boolean<false>().oneOf([false]).defined()
+            : string().oneOf(["auto", "metal", "cuda", "vulkan"]).defined();
+        }).optional(),
+        logLevel: mixed<LlamaLogLevel>()
+          .oneOf(Object.values(LlamaLogLevel))
+          .optional(),
+        logger: lazy((value) => {
+          return typeof value === "function"
+            ? (mixed().nonNullable().optional() as any)
+            : string().defined().nullable().optional();
+        }).optional(),
+        build: string().oneOf(["auto", "never", "forceRebuild"]).optional(),
+        cmakeOptions: object().shape({}).optional(),
+        existingPrebuiltBinaryMustMatchBuildOptions: boolean().optional(),
+        usePrebuiltBinaries: boolean().optional(),
+        progressLogs: boolean().optional(),
+        skipDownload: boolean().optional(),
+        vramPadding: lazy((value) => {
+          return typeof value === "function"
+            ? (mixed().nonNullable().optional() as any)
+            : number().defined().optional();
+        }).optional(),
+        debug: boolean().optional(),
+      }).optional(),
+      modelOptions: object()
+        .shape({
+          modelPath: string().defined().optional(),
+          gpuLayers: lazy((value) => {
+            if (typeof value === "string") {
+              return string<"auto" | "max">()
+                .defined()
+                .oneOf(["auto", "max"])
+                .optional();
+            }
+
+            if (typeof value === "number") {
+              return number().defined().optional();
+            }
+
+            return object().shape({
+              min: number().defined().optional(),
+              max: number().defined().optional(),
+              fitContext: object()
+                .shape({
+                  contextSize: number().defined().optional(),
+                  embeddingContext: boolean().defined().optional(),
+                })
+                .optional(),
+            });
+          }).optional(),
+          vocabOnly: boolean().optional(),
+          useMmap: boolean().optional(),
+          useMlock: boolean().optional(),
+          checkTensors: boolean().optional(),
+          lora: lazy((value) => {
+            return typeof value === "string"
+              ? string().defined().optional()
+              : object().shape({
+                  adapters: array()
+                    .of(
+                      object().shape({
+                        loraFilePath: string().required(),
+                        baseModelPath: string().optional(),
+                        scale: number().optional(),
+                      })
+                    )
+                    .required(),
+                  threads: number().optional(),
+                  onLoadProgress: lazy((value) => {
+                    if (typeof value === "function") {
+                      return mixed().nonNullable() as any;
+                    }
+
+                    throw new Error("onLoadProgress must be a function");
+                  }).optional(),
+                });
+          }).optional(),
+          ignoreMemorySafetyChecks: boolean().optional(),
+        })
+        .optional(),
+      contextOptions: object()
+        .shape({
+          sequences: number().optional(),
+          seed: number().nullable(),
+          contextSize: lazy((value) => {
+            if (typeof value === "string") {
+              return string<"auto">().defined().oneOf(["auto"]);
+            }
+
+            if (typeof value === "number") {
+              return number().defined();
+            }
+
+            return object().shape({
+              min: number().defined().optional(),
+              max: number().defined().optional(),
+            });
+          }).optional(),
+        })
+        .optional(),
+      batchSize: number().optional(),
+      threads: number().optional(),
+      batching: object().shape({
+        dispatchSchedule: lazy((value) => {
+          return typeof value === "function"
+            ? (mixed().nonNullable().optional() as any)
+            : string().oneOf(["nextTick"]).defined().optional();
+        }).optional(),
+        itemPrioritizationStrategy: lazy((value) => {
+          return typeof value === "function"
+            ? (mixed().nonNullable().optional() as any)
+            : string()
+                .oneOf(["maximumParallelism", "firstInFirstOut"])
+                .defined()
+                .optional();
+        }).optional(),
+      }),
+      createSignal: lazy((value) => {
+        if (typeof value === "function" || value === undefined) {
+          return mixed().optional();
+        }
+
+        throw new Error("createSignal must be a function");
+      }).optional(),
+      ignoreMemorySafetyChecks: boolean().optional(),
+    })
+    .optional(),
+});
+
+export const validateConfig = <C extends PoyroVitestConfig>(
+  config: C
+): PoyroVitestConfig => {
+  const configSchema = _configSchema as Schema<PoyroVitestConfig>;
+
+  return configSchema.validateSync(config, { strict: true });
+};

--- a/packages/vitest/tsup.config.ts
+++ b/packages/vitest/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, type Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
-  entryPoints: ["src/index.ts"],
+  entryPoints: ["src/index.ts", "src/config.ts"],
   format: ["esm"],
   clean: false,
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,9 +202,15 @@ importers:
       node-llama-cpp:
         specifier: 3.0.0-beta.36
         version: 3.0.0-beta.36(typescript@5.5.3)
+      radash:
+        specifier: ^12.1.0
+        version: 12.1.0
       vitest:
         specifier: '>= 1.6.0'
         version: 1.6.0(@types/node@20.14.9)(happy-dom@8.9.0)
+      yup:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -4071,6 +4077,9 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -4083,6 +4092,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  radash@12.1.0:
+    resolution: {integrity: sha512-b0Zcf09AhqKS83btmUeYBS8tFK7XL2e3RvLmZcm0sTdF1/UUlHSsjXdCcWNxe7yfmAlPve5ym0DmKGtTzP6kVQ==}
+    engines: {node: '>=14.18.0'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4550,6 +4563,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -4575,6 +4591,9 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -4707,6 +4726,10 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
@@ -5036,6 +5059,9 @@ packages:
   yoctocolors-cjs@2.1.1:
     resolution: {integrity: sha512-c6T13b6qYcJZvck7QbEFXrFX/Mu2KOjvAGiKHmYMUg96jxNpfP6i+psGW72BOPxOIDUJrORG+Kyu7quMX9CQBQ==}
     engines: {node: '>=18'}
+
+  yup@1.4.0:
+    resolution: {integrity: sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -9487,6 +9513,8 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  property-expr@2.0.6: {}
+
   proxy-from-env@1.1.0: {}
 
   pseudomap@1.0.2: {}
@@ -9494,6 +9522,8 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radash@12.1.0: {}
 
   rc@1.2.8:
     dependencies:
@@ -10070,6 +10100,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-case@1.0.3: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.8.0: {}
@@ -10087,6 +10119,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toposort@2.0.2: {}
 
   tr46@0.0.3:
     optional: true
@@ -10207,6 +10241,8 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
+
+  type-fest@2.19.0: {}
 
   type-fest@3.13.1: {}
 
@@ -10616,5 +10652,12 @@ snapshots:
   yocto-queue@1.0.0: {}
 
   yoctocolors-cjs@2.1.1: {}
+
+  yup@1.4.0:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
What's done:
- Poyro:
  - Create `config.ts` in Poyro `src` folder.
  - Add `src/config.ts` to `tsup.config.ts`.

What needs to be done:
- CLI **[P1 - I can do this with guidance]**:
  - Add logic to script to build `llamacpp.config.js` alongside existing config files.
  - Default parameters in this file should be (include comments as documentation for user):
    - `LlamaOptions`: `{vramPadding: 0, debug: False // Set to true to see model and hardware configuration}`
    - `LlamaModelOptions`:  `{gpuLayers: 33}`
    - `LlamaContext`: `{contextSize: 512, seed: 9}`
 - Poyro **[P0 - I got stuck by the first bullet here]**:
   - Figure out how to read `llamacpp.config.js` if it exists in `makeModel`. If it does not, construct with the default parameters above.
   -  Once that configuration is read or created, its components need to be passed to `getLlama`, `llama.getModel`, and `this.model.createContext` within `PoyroModelCore._getContextSequence`.