### PR TITLE
Move from Llama-3 to Phi-3.1

### DIFF
--- a/packages/vitest/constants.json
+++ b/packages/vitest/constants.json
@@ -1,7 +1,7 @@
 {
   "model": {
-    "org": "mradermacher",
-    "repo": "Meta-Llama-3-8B-Instruct-GGUF",
-    "filename": "Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"
+    "org": "bartowski",
+    "repo": "Phi-3.1-mini-4k-instruct-GGUF",
+    "filename": "Phi-3.1-mini-4k-instruct-Q4_K_M.gguf"
   }
 }


### PR DESCRIPTION
I created an eval set from 1000 examples from the Prometheus dataset. Here are the results:

Llama-3
![llama-3-1000](https://github.com/poyro/poyro/assets/149917370/4764d751-6b54-422e-817b-a96283d4c7a6)

QuantFactory Phi-3
![phi-3-1000](https://github.com/poyro/poyro/assets/149917370/1ea70165-75be-4a91-8cbd-050384b1b350)

Bartowski Phi-3
![phi-3-1000-bartowski](https://github.com/poyro/poyro/assets/149917370/4c77df32-fdd0-4783-ac9e-293486576757)

Bartowski Phi 3.1
![phi-3 1-1000](https://github.com/poyro/poyro/assets/149917370/064fea33-76b8-4a68-84f3-29c7251c615a)

We can see Bartowski Phi 3.1 achieves basically the same accuracy, 76.0% (vs. 76.3% for Llama) but is half the size 2.39GB (vs. 4.93 GB) and runs 1000 tests in 1270s (vs. 3427s), so almost 3x faster. This model came out 2 days ago -- what a time to work in the space :)

It is odd that Phi 3.1 is slower than Phi-3 as they are the exact same architecture. I expect perhaps there are some differences in the quantization approach or model itself that are not super well supported in the llama-cpp build in node-llama. This is likely to be solved in the near future, so we'll return to this question.

Need to commit the evaluation logic, but this can be done in a separate patch to not block the next release.